### PR TITLE
Back-port ag/2491664

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -72,6 +72,7 @@
     <uses-permission android:name="android.permission.READ_SEARCH_INDEXABLES" />
     <uses-permission android:name="android.permission.OEM_UNLOCK_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.HIDE_NON_SYSTEM_OVERLAY_WINDOWS" />
     <uses-permission android:name="cyanogenmod.permission.HARDWARE_ABSTRACTION_ACCESS" />
     <uses-permission android:name="com.cyanogen.permission.REQUEST_KILL_SWITCH_OP" />
     <uses-permission android:name="cyanogenmod.permission.FINISH_SETUP" />

--- a/src/com/android/settings/accessibility/ToggleAccessibilityServicePreferenceFragment.java
+++ b/src/com/android/settings/accessibility/ToggleAccessibilityServicePreferenceFragment.java
@@ -33,6 +33,8 @@ import android.provider.Settings;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
 import android.view.accessibility.AccessibilityManager;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -48,6 +50,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static android.view.WindowManager.LayoutParams.PRIVATE_FLAG_HIDE_NON_SYSTEM_OVERLAY_WINDOWS;
 
 public class ToggleAccessibilityServicePreferenceFragment
         extends ToggleFeaturePreferenceFragment implements DialogInterface.OnClickListener {
@@ -182,6 +186,10 @@ public class ToggleAccessibilityServicePreferenceFragment
                         .create();
                 ad.create();
                 ad.getButton(AlertDialog.BUTTON_POSITIVE).setFilterTouchesWhenObscured(true);
+                Window window = ad.getWindow();
+                WindowManager.LayoutParams params = window.getAttributes();
+                params.privateFlags |= PRIVATE_FLAG_HIDE_NON_SYSTEM_OVERLAY_WINDOWS;
+                window.setAttributes(params);                
                 return ad;
             }
             case DIALOG_ID_DISABLE_WARNING: {


### PR DESCRIPTION
Bug: 62196835
Test: Verify overlays disappear on a11y capabilities
dialog.

Change-Id: Ic675012dd9faa8e53d1d4b126b3ba68fecdab992
(cherry picked from commit e76e053595660ed2a75adb33ee124a7bfbed164b)
CVE-2017-0752